### PR TITLE
a patch for Xcode12

### DIFF
--- a/ios/Classes/SwiftSoundModePlugin.swift
+++ b/ios/Classes/SwiftSoundModePlugin.swift
@@ -3,6 +3,7 @@ import UIKit
 import MuteDetect
 public class SwiftSoundModePlugin: NSObject, FlutterPlugin {
   var str: String = "default" 
+  var count: Int = 0
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "method.channel.audio", binaryMessenger: registrar.messenger())
     let instance = SwiftSoundModePlugin()
@@ -18,6 +19,8 @@ public class SwiftSoundModePlugin: NSObject, FlutterPlugin {
                self.str+=String(self.count);
           }
           result(self.str);
+        default:
+          break;
       }
   }
 }


### PR DESCRIPTION
Hi, thanks for this useful library.

When I try to use this library with Xcode12 I got a following error:
```
    Command CompileSwift failed with a nonzero exit code
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:17:21:
    error: value of type 'SwiftSoundModePlugin' has no member 'count'
                   self.count=self.count+1;
                   ~~~~ ^~~~~
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:17:32:
    error: value of type 'SwiftSoundModePlugin' has no member 'count'
                   self.count=self.count+1;
                              ~~~~ ^~~~~
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:18:38:
    error: argument passed to call that takes no arguments
                   self.str+=String(self.count);
                                    ~~~~~^~~~~
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:18:38:
    error: value of type 'SwiftSoundModePlugin' has no member 'count'
                   self.str+=String(self.count);
                                    ~~~~ ^~~~~
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:13:7:
    error: switch must be exhaustive
          switch call.method {
          ^
    /Users/a_user/.pub-cache/bin/hosted/pub.dartlang.org/sound_mode-0.2.0/ios/Classes/SwiftSoundModePlugin.swift:13:7:
    note: do you want to add a default clause?
          switch call.method {
```

This pull request is to solve the error.

I'm a non-Swift guy, so I'm not sure this is the right way or not.
But the error has gone on my side anyway.
