### PR TITLE
Add Namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.tryingoutsomething.soundmode.sound_mode'
     defaultConfig {
         compileSdk 34
         minSdkVersion 16


### PR DESCRIPTION
Namespace is required by newest Android Gradle. Added to support the newest requirements.